### PR TITLE
fix: sonic url in footer

### DIFF
--- a/module/sidebar.tmpl
+++ b/module/sidebar.tmpl
@@ -18,7 +18,7 @@
         <a target="_blank" href="#">
             <a href="https://www.caicai.me">Designed by CaiCai</a>
             <div class="by_sonic">
-                <a href="https://go-sonic.org" target="_blank">Proudly published with Sonic</a>
+                <a href="https://github.com/go-sonic/sonic" target="_blank">Proudly published with Sonic</a>
             </div>
             <div class="footer_text">
                 {{template "global.footer" .}}


### PR DESCRIPTION
the link in the footer `https://go-sonic.org` is inaccessible. It might even take users to some unexpected pages. This PR replaces it with `https://github.com/go-sonic/sonic`.